### PR TITLE
build(k8s): override default app name carnets

### DIFF
--- a/.k8s/app.values.yml
+++ b/.k8s/app.values.yml
@@ -5,6 +5,8 @@
 image:
   repository: registry.gitlab.factory.social.gouv.fr/socialgouv/carnets
 
+nameOverride: carnets
+
 labels:
   app.kubernetes.io/part-of: carnets
   owner: carnets


### PR DESCRIPTION
<img src=https://media.giphy.com/media/pXRzGDCTL6oMw/giphy.gif width=693>