### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,27 @@
 name: Release
+
 on:
   workflow_dispatch:
   push:
     branches: [master, alpha, beta, next]
+
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+    - name: Get GitHub App Token
+      id: token
+      uses: SocialGouv/token-bureau@main
+      with:
+        token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+        audience: socialgouv
+
     - uses: SocialGouv/actions/autodevops-release@v1
       with:
-        github-token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+        github-token: ${{ steps.token.outputs.token }}
         author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
         author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.