### PR TITLE
Refactor: Fix layout issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,23 @@ a[aria-disabled="true"] {
   pointer-events: none;
   text-decoration: none;
 }
+
+.team-title .name-description h2 {
+  @apply text-4xl;
+}
+
+.team-title {
+  @apply w-12 h-12;
+}
+
+.kpis {
+  @apply py-1;
+}
+
+.kpis .kpi .value {
+  @apply text-lg;
+}
+
+.kpis .kpi .name {
+  @apply text-sm;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default async function Layout({ children }: { children: JSX.Element }) {
       <body>
         <DsfrProvider lang={lang}>
           <Header session={session} />
-          <div className="fr-container flex">{children}</div>
+          <div className="fr-container flex p-4 md:p-6 lg:p-8">{children}</div>
           <Footer />
         </DsfrProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
 
   return (
     <>
-      <aside className="flex-initial w-80">
+      <aside className="hidden md:block flex-initial w-80">
         <Teams />
       </aside>
       <main className="flex-1 pt-12 mb-8">

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
 
   return (
     <main>
-      <section className="mt-12">
+      <section className="mt-6">
         <h2 className="fr-h2">Nombre de publications par semaine</h2>
         <div className="h-96 relative mb-12">
           <Chart stats={posts_stat} />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,5 +1,5 @@
 .team-title {
-  @apply flex flex-1 gap-x-6 mt-10;
+  @apply flex flex-1 gap-x-6 mt-10 w-12 h-12;
 }
 
 .team-title .name-description {
@@ -7,7 +7,7 @@
 }
 
 .team-title .name-description h2 {
-  @apply text-5xl;
+  @apply text-4xl;
 }
 
 .team-title .actions {
@@ -24,7 +24,7 @@
 
 article.post {
   @apply bg-gray-50;
-  @apply p-3 flex flex-col gap-y-6 rounded-sm;
+  @apply p-3 flex flex-col gap-y-4 rounded-sm;
   @apply dark:bg-[color:var(--background-raised-grey)];
 
   filter: drop-shadow(var(--raised-shadow));
@@ -40,7 +40,7 @@ article.post .header .text {
 }
 
 article.post .kpis {
-  @apply flex divide-x py-2;
+  @apply flex divide-x py-1;
 
   border: 1px solid var(--border-default-grey);
   background-color: var(--background-default-grey);
@@ -51,11 +51,11 @@ article.post .kpis .kpi {
 }
 
 article.post .kpis .kpi .value {
-  @apply text-center truncate font-semibold text-xl;
+  @apply text-center truncate font-semibold text-lg;
 }
 
 article.post .kpis .kpi .name {
-  @apply flex-1 truncate text-center;
+  @apply flex-1 truncate text-center text-sm;
 }
 
 article.post .tab-panel {
@@ -67,7 +67,7 @@ article.post .tab-panel .tabs {
 }
 
 article.post .tab-panel .tabs .tab {
-  @apply flex flex-1 text-center;
+  @apply flex flex-1 text-center text-sm;
   @apply relative top-px;
   @apply border;
   @apply rounded-t-sm;
@@ -97,7 +97,7 @@ article.post .tab-panel .panels {
 }
 
 article.post .tab-panel .panels .panel {
-  @apply flex-1 hidden min-h-[13rem] overflow-auto;
+  @apply flex-1 hidden min-h-[10rem] overflow-auto;
   @apply flex-col max-h-52;
 }
 
@@ -125,7 +125,7 @@ article.post .actions {
 }
 
 .markdown-body {
-  @apply flex-1 p-3;
+  @apply flex-1 p-3 leading-tight;
   color: var(--text-default-grey);
   background-color: var(--background-default-grey);
 }

--- a/src/components/post.tsx
+++ b/src/components/post.tsx
@@ -32,7 +32,7 @@ export default function Post({
   onDeletion: (id?: string) => void;
 }) {
   return (
-    <article className="post">
+    <article className="post gap-y-4">
       <div className="header">
         <div className="avatar">
           {hideLogo ? (
@@ -52,18 +52,18 @@ export default function Post({
       <KPIs kpis={data.kpis?.slice(0, 3) || []}></KPIs>
       <TabPanel>
         <Tabs>
-          <Tab disabled={!data.priorities.length}>Priorités</Tab>
-          <Tab disabled={!data.needs.length}>Besoins</Tab>
-          <Tab disabled={!data.term.length}>Échéances</Tab>
+          <Tab disabled={!data.priorities.length} className="text-sm">Priorités</Tab>
+          <Tab disabled={!data.needs.length} className="text-sm">Besoins</Tab>
+          <Tab disabled={!data.term.length} className="text-sm">Échéances</Tab>
         </Tabs>
         <Panels>
-          <div className="markdown-body">
+          <div className="markdown-body leading-tight">
             <Markdown remarkPlugins={[remarkGfm]}>{data.priorities}</Markdown>
           </div>
-          <div className="markdown-body">
+          <div className="markdown-body leading-tight">
             <Markdown remarkPlugins={[remarkGfm]}>{data.needs}</Markdown>
           </div>
-          <div className="markdown-body">
+          <div className="markdown-body leading-tight">
             <Markdown remarkPlugins={[remarkGfm]}>{data.term}</Markdown>
           </div>
         </Panels>

--- a/src/components/posts.tsx
+++ b/src/components/posts.tsx
@@ -43,7 +43,7 @@ export default function Posts({
   }
 
   return (
-    <section className="posts">
+    <section className="posts gap-y-4">
       <modal.Component title="Suppression">
         <div className="relative">
           <div className={`${isLoading ? "invisible" : ""}`}>

--- a/src/components/team-title.tsx
+++ b/src/components/team-title.tsx
@@ -4,15 +4,16 @@ export default function TeamTitle({ team }: { team?: Team }) {
   return (
     <div className="team-title">
       <Image
-        width={200}
-        height={200}
+        width={48}
+        height={48}
         alt="Picture of the team"
         src={team?.avatarUrl || ""}
+        className="w-12 h-12"
       />
       <div className="name-description">
-        <h2>{team?.name}</h2>
+        <h2 className="text-4xl">{team?.name}</h2>
         <div>{team?.description}</div>
-        <div className="members">
+        <div className="members mt-2">
           {team?.members?.nodes.map(({ name, avatarUrl, login }) => (
             <Image
               width={42}


### PR DESCRIPTION
Implement layout and styling changes to improve compactness and responsiveness.

* **TeamTitle Component:**
  - Reduce team avatar size to `w-12 h-12`.
  - Reduce font size for team name to `text-4xl`.
  - Add margin-top to members section with `mt-2`.

* **KPIs Component:**
  - Reduce padding in `.kpis` class to `py-1`.
  - Reduce font size for KPI values to `text-lg`.
  - Reduce font size for KPI labels to `text-sm`.

* **Post Component:**
  - Reduce size of tab buttons to `text-sm`.
  - Reduce spacing within posts to `gap-y-4`.
  - Reduce default height for tab content areas to `min-h-[10rem]`.
  - Make text in markdown bodies denser with `leading-tight`.

* **Main Layout:**
  - Adjust main content padding for different viewports with `p-4 md:p-6 lg:p-8`.
  - Hide sidebar on small screens with `hidden md:block`.
  - Reduce margin-top of the first section in stats page to `mt-6`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SocialGouv/carnets/pull/477?shareId=4892cc72-3758-4af7-b774-0322c6501bb7).